### PR TITLE
Move all GraphQL Queries and Mutations into a dedicated /graphql folder.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "ipfs"
+    ]
+}

--- a/components/Comments/index.js
+++ b/components/Comments/index.js
@@ -14,6 +14,8 @@ import LoadingBackdrop from '../LoadingBackdrop'
 import Comment from './comment'
 import { ERROR_TYPES } from '../../constants'
 
+import { mutations } from '../../graphql'
+
 const PostComment = styled(Button)({
   float: 'right',
   'margin-top': '10px'
@@ -28,17 +30,7 @@ const CommentContainer = styled('div')({
   'margin-top': '20px'
 })
 
-const UPLOAD_COMMENT = gql`
-  mutation uploadComment($commentText: String!, $postTxId: String!, $communityTxId: String!, $ethAddr: String!, $timestamp: Int!) {
-    uploadComment(commentText: $commentText, postTxId: $postTxId, communityTxId: $communityTxId, ethAddr: $ethAddr, timestamp: $timestamp) {
-      postText
-      timestamp
-      user {
-        address
-      }
-    }
-  }
-`
+const UPLOAD_COMMENT = gql(mutations.uploadComment)
 
 const Comments = ({ comments, communityTxId, postTxId }) => {
   const [newComment, setNewComment] = useState('')

--- a/components/CommunitySelector/index.js
+++ b/components/CommunitySelector/index.js
@@ -34,6 +34,14 @@ const CommunitySelector = ({ handleSelection, placeHolder, disabled }) => {
     setCommunities(Object.values(coms))
   }, [roles])
 
+  // Help the user. If there's only one community to select, pick it for them.
+  useEffect(() => {
+    if (Array.isArray(communities) && communities.length === 1) {
+      const [community] = communities
+      setActiveCommunity(community)
+    }
+  }, [communities, setCommunities])
+
   return (
     <CommunitySelect
       labelId='input-label'

--- a/components/Editor/ContentEditor.js
+++ b/components/Editor/ContentEditor.js
@@ -25,6 +25,8 @@ import {
   getYoutubeVideo
 } from './CustomBlocks'
 
+import { mutations } from '../graphql'
+
 registerCustomBlocks()
 
 const FormTextField = styled(Input)({
@@ -85,13 +87,7 @@ const EditorContainer = styled(Editor)({
   top: '-50px'
 })
 
-const UPLOAD_IMAGE = gql`
-  mutation uploadImage($image: Image!, $address: String!) {
-    uploadImage(image: $image, address: $address) {
-      txId
-    }
-  }
-`
+const UPLOAD_IMAGE = gql(mutations.uploadImage)
 
 const ContentEditor = ({ title, subtitle, postText, featuredImg, setTitle, setSubtitle, setPostText, setFeaturedImage, isEditing }) => {
   const { account } = useWeb3React()

--- a/components/Editor/ContentEditor.js
+++ b/components/Editor/ContentEditor.js
@@ -25,7 +25,7 @@ import {
   getYoutubeVideo
 } from './CustomBlocks'
 
-import { mutations } from '../graphql'
+import { mutations } from '../../graphql'
 
 registerCustomBlocks()
 

--- a/components/Post/index.js
+++ b/components/Post/index.js
@@ -87,7 +87,7 @@ const DELETE_POST = gql`
 
 const Post = ({ post, comments }) => {
   const { account } = useWeb3React()
-  const { title, subtitle, postText,  user, txId, community } = post
+  const { title, subtitle, postText, user, txId, community } = post
   const [isDeleting, setIsDeleting] = useState(false)
   const [deletePostFromDb, { error }] = useMutation(DELETE_POST)
   const router = useRouter()

--- a/context/Role.js
+++ b/context/Role.js
@@ -6,6 +6,8 @@ import { useWeb3React } from '@web3-react/core'
 import { useLazyQuery, gql } from '@apollo/client'
 import useAuth from '../hooks/useAuth'
 
+import { queries } from '../graphql';
+
 export const RoleContext = createContext({
   roles: []
 })
@@ -57,15 +59,4 @@ export function RoleProvider ({ children }) {
   )
 }
 
-const ROLE_QUERY = gql`
-  query {
-    userRoles {
-      title
-      community {
-        txId
-        name
-        slug
-      }
-    }
-  }
-`
+const ROLE_QUERY = gql(queries.getUserRoles)

--- a/graphql/index.ts
+++ b/graphql/index.ts
@@ -1,0 +1,2 @@
+export * as queries from './queries'
+export * as mutations from './mutations'

--- a/graphql/mutations.ts
+++ b/graphql/mutations.ts
@@ -1,0 +1,56 @@
+export const uploadPost = `
+  mutation UploadPost($postUpload: PostUpload!, $communityTxId: String!) {
+    uploadPost(postUpload: $postUpload, communityTxId: $communityTxId) {
+      txId
+      title
+      postText
+      subtitle
+      timestamp
+      canonicalLink
+      community {
+        name
+      }
+      user {
+        address
+      }
+    }
+  }
+`
+
+export const getSignInToken = `
+  mutation getToken($addr: String!) {
+    getSignInToken(addr: $addr)
+  }
+`
+
+export const authAccount = `
+  mutation auth($sig: String!, $addr: String!) {
+    authAccount(signature: $sig, addr: $addr)
+  }
+`
+
+export const verifyToken = `
+  mutation validate($token: String!) {
+    verifyToken(token: $token)
+  }
+`
+
+export const uploadImage = `
+  mutation uploadImage($image: Image!, $address: String!) {
+    uploadImage(image: $image, address: $address) {
+      txId
+    }
+  }
+`
+
+export const uploadComment = `
+  mutation uploadComment($commentText: String!, $postTxId: String!, $communityTxId: String!, $ethAddr: String!, $timestamp: Int!) {
+    uploadComment(commentText: $commentText, postTxId: $postTxId, communityTxId: $communityTxId, ethAddr: $ethAddr, timestamp: $timestamp) {
+      postText
+      timestamp
+      user {
+        address
+      }
+    }
+  }
+`

--- a/graphql/queries.ts
+++ b/graphql/queries.ts
@@ -147,3 +147,23 @@ export const getUserRoles = `
     }
   }
 `
+
+export const getCommunityPage = `
+  query ComPage($slug: String) {
+      community(slug: $slug) {
+        id
+        name
+        txId
+        tokenAddress
+        tokenSymbol
+        description
+        imageTxId
+        readRequirement
+        owner {
+          name
+          image
+        }
+        showOwner
+      }
+    }
+`

--- a/graphql/queries.ts
+++ b/graphql/queries.ts
@@ -1,0 +1,149 @@
+export const getAllCommunities = `
+  query {
+    allCommunities {
+      id
+      name
+      txId
+      tokenAddress
+      tokenSymbol
+      description
+      imageTxId
+      slug
+      owner {
+        name
+      }
+      showOwner
+    }
+  }
+`
+
+export const postPreview = `
+  query postpage($txId: String!, $slug: String!) {
+    postPreview (txId: $txId) {
+      id
+      title
+      subtitle
+      timestamp
+      txId
+      featuredImg
+      canonicalLink
+    }
+    community(slug: $slug) {
+      id
+      name
+      txId
+      tokenAddress
+      tokenSymbol
+      description
+      imageTxId
+      readRequirement
+      owner {
+        name
+        image
+      }
+    }
+  }
+`
+
+export const getPosts = `
+  query posts($slug: String) {
+    posts (communitySlug: $slug) {
+      id
+      title
+      subtitle
+      timestamp
+      txId
+      featuredImg
+      community {
+        name
+        readRequirement
+        tokenSymbol
+      }
+      user {
+        name
+      }
+    }
+  }
+`
+
+export const getPost = `
+  query getPost($txId: String!, $userToken: String!) {
+    getPost(txId: $txId, userToken: $userToken) {
+      post {
+        id
+        title
+        postText
+        subtitle
+        timestamp
+        featuredImg
+        canonicalLink
+        txId
+        community {
+          name
+          slug
+          txId
+        }
+        user {
+          address
+          name
+          image
+        }
+      }
+      comments {
+        postText
+        timestamp
+        user {
+          address
+          name
+          image
+        }
+      }
+      userBalance
+      readRequirement
+      tokenSymbol
+      tokenAddress
+    }
+  }
+`
+
+export const getPostPreview = `
+  query posts($txId: String!) {
+    postPreview (txId: $txId) {
+      id
+      title
+      subtitle
+      timestamp
+      txId
+      featuredImg
+      canonicalLink
+    }
+  }
+`
+
+export const getUser = `
+  query user($ethAddr: String) {
+    user(ethAddr: $ethAddr) {
+      name,
+      id
+    }
+  }
+`
+
+export const isNameAvailable = `
+  query isNameAvailable($name: String!) {
+    isNameAvailable(name: $name)
+  }
+`
+
+export const getUserRoles = `
+  query {
+    userRoles {
+      title
+      community {
+        txId
+        name
+        slug
+      }
+    }
+  }
+`

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -4,6 +4,8 @@ import {
 } from '@apollo/client'
 import { ERROR_TYPES } from '../constants'
 
+import { queries } from '../graphql'
+
 export const useErrorReporting = (type, error, request) => {
   if (error?.message) {
     // TODO: add mixpanel so we can error report
@@ -15,15 +17,18 @@ export const useErrorReporting = (type, error, request) => {
   }
 }
 
-export const GET_ALL_COMMUNITIES = gql`
-  query {
-    allCommunities {
-      id
-      name
-      txId
-      slug
-    }
-  }`
+// XXX: @Sam: This used to be:
+// query {
+//   allCommunities {
+//     id
+//     name
+//     txId
+//     slug
+//   }
+// }
+// Hope it makes sense to reuse the existing query here. It'll return
+// additional unnecessary data you're not interested in.
+export const GET_ALL_COMMUNITIES = gql(queries.getAllCommunities)
 
 /**
  * Get all communities
@@ -37,14 +42,7 @@ export const useCommunities = () => {
 }
 
 export const useUser = (ethAddr) => {
-  const GET_USER = gql`
-    query user($ethAddr: String) {
-      user(ethAddr: $ethAddr) {
-        name,
-        id
-      }
-    }
-    `
+  const GET_USER = gql(queries.getUser)
   const { data, loading, error } = useQuery(GET_USER, {
     variables: {
       ethAddr: ethAddr
@@ -55,11 +53,7 @@ export const useUser = (ethAddr) => {
 }
 
 export const useIsNameAvailable = (name) => {
-  const IS_NAME_AVAILABLE = gql`
-    query isNameAvailable($name: String!) {
-      isNameAvailable(name: $name)
-    }
-  `
+  const IS_NAME_AVAILABLE = gql(queries.isNameAvailable)
 
   const result = useQuery(IS_NAME_AVAILABLE, {
     variables: {

--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -6,24 +6,14 @@ import { useMutation, gql } from '@apollo/client'
 import { ethers } from 'ethers'
 import { AuthContext } from '../context/Auth'
 
-const SIGN_IN_TOKEN = gql`
-  mutation getToken($addr: String!) {
-    getSignInToken(addr: $addr)
-  }
-`
+import { mutations } from '../graphql'
 
-const AUTHENTICATE = gql`
-  mutation auth($sig: String!, $addr: String!) {
-    authAccount(signature: $sig, addr: $addr)
-  }
-`
+const SIGN_IN_TOKEN = gql(mutations.getSignInToken)
+
+const AUTHENTICATE = gql(mutations.authAccount)
 
 // validate token isn't really a mutation but we want it to execute like one
-const VALIDATE_TOKEN = gql`
-  mutation validate($token: String!) {
-    verifyToken(token: $token)
-  }
-`
+const VALIDATE_TOKEN = gql(mutations.verifyToken)
 
 const useAuth = () => {
   const { setAuthToken, authToken, setGettingToken, isGettingToken } = useContext(AuthContext)

--- a/hooks/usePosts.js
+++ b/hooks/usePosts.js
@@ -7,80 +7,13 @@ import { useErrorReporting } from './index'
 import { ERROR_TYPES } from '../constants'
 import { useRouter } from 'next/router'
 
-export const GET_POSTS = gql`
-  query posts($slug: String) {
-    posts (communitySlug: $slug) {
-      id
-      title
-      subtitle
-      timestamp
-      txId
-      featuredImg
-      community {
-        name
-        readRequirement
-        tokenSymbol
-      }
-      user {
-        name
-      }
-    }
-  }
-  `
+import { queries } from '../graphql'
 
-export const GET_POST = gql`
-  query getPost($txId: String!, $userToken: String!) {
-    getPost(txId: $txId, userToken: $userToken) {
-      post {
-        id
-        title
-        postText
-        subtitle
-        timestamp
-        featuredImg
-        canonicalLink
-        txId
-        community {
-          name
-          slug
-          txId
-        }
-        user {
-          address
-          name
-          image
-        }
-      }
-      comments {
-        postText
-        timestamp
-        user {
-          address
-          name
-          image
-        }
-      }
-      userBalance
-      readRequirement
-      tokenSymbol
-      tokenAddress
-    }
-  }
-`
+export const GET_POSTS = gql(queries.getPosts)
 
-const GET_PREVIEW = gql`
-  query posts($txId: String!) {
-    postPreview (txId: $txId) {
-      id
-      title
-      subtitle
-      timestamp
-      txId
-      featuredImg
-      canonicalLink
-    }
-  }
-`
+export const GET_POST = gql(queries.getPost)
+
+const GET_PREVIEW = gql(queries.getPostPreview)
 
 export const usePostPreview = (txId) => {
   const [title, setTitle] = useState(null)

--- a/pages/[comSlug]/index.js
+++ b/pages/[comSlug]/index.js
@@ -9,6 +9,8 @@ import Feed from '../../components/Feed'
 import Toolbar from '../../components/Toolbar'
 import MastHead from '../../components/MastHead'
 
+import { queries } from '../../graphql'
+
 const OUTPOST_API = process.env.NEXT_PUBLIC_OUTPOST_API
 
 const FeedContainer = styled('div')({
@@ -59,25 +61,9 @@ const CommunityPage = ({ community }) => {
 export async function getServerSideProps (context) {
   const slug = context.params.comSlug
 
-  const query = `
-    query ComPage($slug: String) {
-      community(slug: $slug) {
-        id
-        name
-        txId
-        tokenAddress
-        tokenSymbol
-        description
-        imageTxId
-        readRequirement
-        owner {
-          name
-          image
-        }
-        showOwner
-      }
-    }
-  `
+  console.log({ params: context.params })
+
+  const query = queries.getCommunityPage
 
   const res = await axios.post(OUTPOST_API, {
     query,

--- a/pages/[comSlug]/post/[txId].js
+++ b/pages/[comSlug]/post/[txId].js
@@ -201,7 +201,7 @@ export async function getServerSideProps (context) {
   const OUTPOST_API = process.env.NEXT_PUBLIC_OUTPOST_API
   const { txId, comSlug } = context.params
 
-  const query = queries.postPreview;
+  const query = queries.postPreview
 
   const res = await axios.post(OUTPOST_API, {
     query,

--- a/pages/[comSlug]/post/[txId].js
+++ b/pages/[comSlug]/post/[txId].js
@@ -13,6 +13,8 @@ import Post from '../../../components/Post'
 import Toolbar from '../../../components/Toolbar'
 import SEO from '../../../components/seo'
 
+import { queries } from '../../../graphql'
+
 const PostContainer = styled('div')({
   margin: '5em 0',
   padding: '0 20px',
@@ -199,33 +201,7 @@ export async function getServerSideProps (context) {
   const OUTPOST_API = process.env.NEXT_PUBLIC_OUTPOST_API
   const { txId, comSlug } = context.params
 
-  const query = `
-    query postpage($txId: String!, $slug: String!) {
-      postPreview (txId: $txId) {
-        id
-        title
-        subtitle
-        timestamp
-        txId
-        featuredImg
-        canonicalLink
-      }
-      community(slug: $slug) {
-        id
-        name
-        txId
-        tokenAddress
-        tokenSymbol
-        description
-        imageTxId
-        readRequirement
-        owner {
-          name
-          image
-        }
-      }
-    }
-  `
+  const query = queries.postPreview;
 
   const res = await axios.post(OUTPOST_API, {
     query,

--- a/pages/[comSlug]/post/[txId].js
+++ b/pages/[comSlug]/post/[txId].js
@@ -203,8 +203,6 @@ export async function getServerSideProps (context) {
 
   const query = queries.postPreview
 
-  console.log({ txId, comSlug });
-
   const res = await axios.post(OUTPOST_API, {
     query,
     variables: {

--- a/pages/[comSlug]/post/[txId].js
+++ b/pages/[comSlug]/post/[txId].js
@@ -203,6 +203,8 @@ export async function getServerSideProps (context) {
 
   const query = queries.postPreview
 
+  console.log({ txId, comSlug });
+
   const res = await axios.post(OUTPOST_API, {
     query,
     variables: {

--- a/pages/editor.js
+++ b/pages/editor.js
@@ -29,6 +29,8 @@ import {
 import PostActions from '../components/Editor/PostActions'
 import EditorPreview from '../components/Editor/EditorPreview'
 
+import { mutations } from '../graphql';
+
 const ContentEditor = dynamic(import('../components/Editor/ContentEditor'), { ssr: false, loading: () => <LoadingBackdrop isLoading={true} /> })
 
 const converter = new showdown.Converter()
@@ -47,24 +49,7 @@ const WarningText = styled('div')({
   color: '#FF5252'
 })
 
-const UPLOAD_POST = gql`
-  mutation UploadPost($postUpload: PostUpload!, $communityTxId: String!) {
-    uploadPost(postUpload: $postUpload, communityTxId: $communityTxId) {
-      txId
-      title
-      postText
-      subtitle
-      timestamp
-      canonicalLink
-      community {
-        name
-      }
-      user {
-        address
-      }
-    }
-  }
-`
+const UPLOAD_POST = gql(mutations.uploadPost)
 
 const EditorPage = () => {
   const { authToken, fetchToken } = useAuth()

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,6 +7,8 @@ import SEO from '../components/seo'
 import Footer from '../components/Footer'
 import Toolbar from '../components/Toolbar'
 
+import { queries } from '../graphql'
+
 const OUTPOST_API = process.env.NEXT_PUBLIC_OUTPOST_API
 
 const Container = styled('div')({
@@ -119,31 +121,31 @@ const Home = ({ communities }) => {
         </HeaderContainer>
         <DiscoverContainer>
           <Discover>
-          {communities.map((com, i) => {
-            return (
-              <ComContainer
-                key={i}
-                onClick={() => router.push(`/${com.slug}`)}
-              >
-                <ComImgContainer>
-                  <ComImg src={`https://arweave.net/${com.imageTxId}`} />
-                </ComImgContainer>
-                <ComInfo>
-                  <ComName>
-                    {com.name}
-                  </ComName>
-                  <ComDescription>
-                    {com.description}
-                  </ComDescription>
-                  {com.showOwner &&
-                    <ComAuthor>
-                      By {com.owner.name}
-                    </ComAuthor>
-                  }
-                </ComInfo>
-              </ComContainer>
-            )
-          })}
+            {communities.map((com, i) => {
+              return (
+                <ComContainer
+                  key={i}
+                  onClick={() => router.push(`/${com.slug}`)}
+                >
+                  <ComImgContainer>
+                    <ComImg src={`https://arweave.net/${com.imageTxId}`} />
+                  </ComImgContainer>
+                  <ComInfo>
+                    <ComName>
+                      {com.name}
+                    </ComName>
+                    <ComDescription>
+                      {com.description}
+                    </ComDescription>
+                    {com.showOwner &&
+                      <ComAuthor>
+                        By {com.owner.name}
+                      </ComAuthor>
+                    }
+                  </ComInfo>
+                </ComContainer>
+              )
+            })}
           </Discover>
         </DiscoverContainer>
       </Body>
@@ -153,26 +155,8 @@ const Home = ({ communities }) => {
 }
 
 export async function getStaticProps () {
-  const query = `
-    query {
-      allCommunities {
-        id
-        name
-        txId
-        tokenAddress
-        tokenSymbol
-        description
-        imageTxId
-        slug
-        owner {
-          name
-        }
-        showOwner
-      }
-    }
-  `
 
-  const res = await axios.post(OUTPOST_API, { query })
+  const res = await axios.post(OUTPOST_API, { query: queries.getAllCommunities })
 
   const communities = res.data.data.allCommunities
 


### PR DESCRIPTION
So the idea is that if this implementation looks good, I can work on porting over all of the GraphQL statements to the client SDK and expose them there. Then we'd add a dependency on the client.

Once that's done, we can start trying to embed higher level logic based around these low level queries (such as image/comment submission) to the SDK as well.